### PR TITLE
Remove old source file before setting up the new one at upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ If you don't have YunoHost, please consult [the guide](https://yunohost.org/#/in
 A simple, intuitive web app for analysing and decoding data without having to deal with complex tools or programming languages. CyberChef encourages both technical and non-technical people to explore data formats, encryption and compression: encode, decode, format data, parse data, encrypt, decrypt, compress data, extract data, perform arithmetic functions against data, etc.. There are around 300 operations in CyberChef allowing you to carry out simple and complex tasks easily.
 
 
-**Shipped version:** 10.8.2~ynh1
+**Shipped version:** 10.8.2~ynh2
 
 **Demo:** https://gchq.github.io/CyberChef
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -19,7 +19,7 @@ Si vous n’avez pas YunoHost, regardez [ici](https://yunohost.org/#/install) po
 Une application web simple et intuitive pour analyser et décoder des données sans avoir affaire à des outils ou des langages de programmation compliqués. CyberChef s'adresse aussi bien aux utilisateurs expérimentés qu'aux plus novices souhaitant explorer les formats de données, leur chiffrement et leur compression: encoder, décoder, formater, analyser, chiffrer, déchiffrer, compresser, extraire, fonctions arithmétiques, etc.. Il y a en tout près de 300 outils dans CyberChef permettant de réaliser facilement des tâches simples ou complexes.
 
 
-**Version incluse :** 10.8.2~ynh1
+**Version incluse :** 10.8.2~ynh2
 
 **Démo :** https://gchq.github.io/CyberChef
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -4,7 +4,7 @@ id = "cyberchef"
 name = "CyberChef"
 description.en = "Cyber Swiss Army Knife - toolbox for data analysis"
 description.fr = "Cyber-couteau suisse - boîte à outils pour l'analyse de données"
-version = "10.8.2~ynh1"
+version = "10.8.2~ynh2"
 
 maintainers = ["oleole39"]
 

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -24,7 +24,7 @@ index_page=$(basename -s .zip $upstream_source_url).html #this variable will als
 if [ "$upgrade_type" == "UPGRADE_APP" ]
 then
 	ynh_script_progression --message="Upgrading source files..." --weight=10
-	ynh_setup_source --dest_dir="$install_dir"
+	ynh_setup_source --dest_dir="$install_dir" --full_replace=1
 	ynh_replace_string --match_string="$source_filename" --replace_string="$upstream_source_url" --target_file="$install_dir/$index_page" #replace link to local source file with link to upstream source file 
 	chown -R $app:www-data "$install_dir"
 fi


### PR DESCRIPTION
Merging autopatch from Salamandar.

Not having the patch did not apparently cause any malfunction so far, but it was indeed assumed that the old source be fully replaced by the new one.