### PR TITLE
Fix index page name following to upstream release asset name change

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -5,7 +5,7 @@ name = "CyberChef"
 description.en = "Cyber Swiss Army Knife - toolbox for data analysis"
 description.fr = "Cyber-couteau suisse - boîte à outils pour l'analyse de données"
 
-version = "11.1.0~ynh1"
+version = "11.1.0~ynh2"
 
 maintainers = ["oleole39"]
 

--- a/scripts/change_url
+++ b/scripts/change_url
@@ -2,8 +2,8 @@
 
 source /usr/share/yunohost/helpers
 
-upstream_source_url=$(ynh_read_manifest "resources.sources.main.url")
-index_page=$(basename -s .zip $upstream_source_url).html #this variable will also populate the template tag __INDEX_PAGE__ in nginx.conf
+upstream_version=$(ynh_app_upstream_version)
+index_page="CyberChef_v${upstream_version}.html" #this variable will also populate the template tag __INDEX_PAGE__ in nginx.conf
 
 #=================================================
 # MODIFY URL IN NGINX CONF

--- a/scripts/install
+++ b/scripts/install
@@ -4,7 +4,8 @@ source /usr/share/yunohost/helpers
 
 upstream_source_url=$(ynh_read_manifest "resources.sources.main.url")
 source_filename=$(basename $upstream_source_url)
-index_page=$(basename -s .zip $upstream_source_url).html #this variable will also populate the template tag __INDEX_PAGE__ in nginx.conf
+upstream_version=$(ynh_app_upstream_version)
+index_page="CyberChef_v${upstream_version}.html" #this variable will also populate the template tag __INDEX_PAGE__ in nginx.conf
 
 #=================================================
 # DOWNLOAD, CHECK AND UNPACK SOURCE

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -4,8 +4,8 @@ source /usr/share/yunohost/helpers
 
 upstream_source_url=$(ynh_read_manifest "resources.sources.main.url")
 source_filename=$(basename $upstream_source_url)
-#this variable will also populate the template tag __INDEX_PAGE__ in nginx.conf
-index_page=$(basename -s .zip $upstream_source_url).html
+upstream_version=$(ynh_app_upstream_version)
+index_page="CyberChef_v${upstream_version}.html" #this variable will also populate the template tag __INDEX_PAGE__ in nginx.conf
 
 #=================================================
 # DOWNLOAD, CHECK AND UNPACK SOURCE


### PR DESCRIPTION
In v11.1.0, upstream release asset has new naming format which breaks `$index_page` in the package's scripts.
Let's rather hardcode part of the name and make use of `ynh_app_upstream_version` helper to match the required index page.
